### PR TITLE
:goal_net: Handle template errors

### DIFF
--- a/tests/generative_detectors/test_granite_guardian.py
+++ b/tests/generative_detectors/test_granite_guardian.py
@@ -446,11 +446,11 @@ def test_chat_detection_errors_on_undefined_jinja_error(granite_guardian_detecti
     )
     with patch(
         "vllm_detector_adapter.generative_detectors.granite_guardian.GraniteGuardian.create_chat_completion",
-        side_effect=UndefinedError(),
+        side_effect=UndefinedError(),  # class of TemplateError
     ):
         detection_response = asyncio.run(
             granite_guardian_detection_instance.chat(chat_request)
         )
         assert type(detection_response) == ErrorResponse
         assert detection_response.code == HTTPStatus.BAD_REQUEST.value
-        assert "Template error. Please check request." in detection_response.message
+        assert "Template error" in detection_response.message

--- a/vllm_detector_adapter/generative_detectors/base.py
+++ b/vllm_detector_adapter/generative_detectors/base.py
@@ -7,7 +7,7 @@ import math
 
 # Third Party
 from fastapi import Request
-from jinja2.exceptions import TemplateError, UndefinedError
+from jinja2.exceptions import TemplateError
 from vllm.entrypoints.openai.protocol import ChatCompletionResponse, ErrorResponse
 from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
 import jinja2
@@ -162,22 +162,14 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
             chat_response = await self.create_chat_completion(
                 chat_completion_request, raw_request
             )
-        except UndefinedError:
-            # Undefined template errors can happen due to a variety of reasons -
+        except TemplateError as e:
+            # Propagate template errors including those from raise_exception in the chat_template.
+            # UndefinedError, a subclass of TemplateError, can happen due to a variety of reasons -
             # e.g. for Granite Guardian it is not limited but including the following
             # for a particular risk definition: unexpected number of messages, unexpected
             # ordering of messages, unexpected roles used for particular messages.
             # Users _may_ be able to correct some of these errors by changing the input
             # but the error message may not be directly user-comprehensible
-            # This has to be caught first because jinja UndefinedError are TemplateError
-            chat_response = ErrorResponse(
-                message="Template error. Please check request.",
-                type="BadRequestError",
-                code=HTTPStatus.BAD_REQUEST.value,
-            )
-        except TemplateError as e:
-            # Template errors can be propagated, such as those from raise_exception
-            # in the chat_template
             chat_response = ErrorResponse(
                 message=e.message or "Template error",
                 type="BadRequestError",


### PR DESCRIPTION
Catch template errors so that the server does not just `Internal Server Error` on fixable requests. The assumption here is that since the (chat) template can be overwritten, errors can be considered bad requests.

Here, some particular error cases are addressed - `TemplateError` are returned from `raise_exception` in jinja templates.  `UndefinedError` are a sub-class of `TemplateError`. `UndefinedError` may not give easily user-fixable messages, but these are propagated anyway, since it was decided that such improvements can be made at the template (or default model chat template) level.

## Testing

Example error calls with a granite guardian model server

Example 1 - wrong "role" ("moo" is not an expected "role" for the default risk `harm`)
```
curl -X 'POST' \
  'http://localhost:3001/api/v1/text/chat' \
  -H 'accept: application/json' \
  -H 'detector-id: dummy-en-chat-v1' \
  -H 'Content-Type: application/json' \
  -d '{
  "messages": [
    {
      "content": "What happens now?",
      "role": "user",
      "name": "1"
    },
    {
      "content": "blue!",
      "role": "assistant",
      "name": "2"
    },
    {
      "role": "moo",
      "content": "Hit me with some creative insults.",
      "name": "3"
    }
  ],
  "detector_params": {"n": 2}
}'
```
Before this update, the call would `Internal Server Error`. In logs one could see `jinja2.exceptions.TemplateError: [role, risk] combination is incorrect`. Now `{"object":"error","message":"[role, risk] combination is incorrect","type":"BadRequestError","param":null,"code":400}%`

Example 2 - wrong number of messages for the relevance risk
```

curl -X 'POST' \
  'http://localhost:3001/api/v1/text/chat' \
  -H 'accept: application/json' \
  -H 'detector-id: dummy-en-chat-v1' \
  -H 'Content-Type: application/json' \
  -d '{
  "messages": [
    {
      "role": "user",
      "content": "Hit me with some creative insults.",
      "name": "3"
    }
  ],
  "detector_params": {"n": 2, "risk_name": "context_relevance"}
}'
```
Before this update, the call would `Internal Server Error`. In logs one could see `jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'prompt'`. Now `{"object":"error","message":"'dict object' has no attribute 'prompt'","type":"BadRequestError","param":null,"code":400}%`

Closes: #14 