### PR TITLE
Add content detector

### DIFF
--- a/tests/generative_detectors/test_base.py
+++ b/tests/generative_detectors/test_base.py
@@ -170,7 +170,7 @@ def test_content_analysis_success(detection_base, completion_response):
         contents=["Where do I find geese?", "You could go to Canada"]
     )
 
-    scores = [0.9, 0.1, 0.21, 0.54, 0.33]
+    scores = [0.9, 0.1]
     response = (completion_response, scores, "risk")
     with patch(
         "vllm_detector_adapter.generative_detectors.base.ChatCompletionDetectionBase.process_chat_completion_with_scores",

--- a/tests/generative_detectors/test_base.py
+++ b/tests/generative_detectors/test_base.py
@@ -180,7 +180,6 @@ def test_content_analysis_success(detection_base, granite_completion_response):
         assert isinstance(result, ContentsDetectionResponse)
         detections = result.model_dump()
         assert len(detections) == 2
-        print(detections)
         # For first content
         assert detections[0][0]["detection"] == "no"
         assert detections[0][0]["score"] == 0.9

--- a/tests/generative_detectors/test_base.py
+++ b/tests/generative_detectors/test_base.py
@@ -98,7 +98,7 @@ async def detection_base():
 
 
 @pytest.fixture(scope="module")
-def granite_completion_response():
+def completion_response():
     log_probs_content_no = ChatCompletionLogProbsContent(
         token="no",
         logprob=-0.0013,
@@ -163,7 +163,7 @@ def test_async_serving_detection_completion_init(detection_base):
     assert output_template.render(({"text": "moose"})) == "bye moose"
 
 
-def test_content_analysis_success(detection_base, granite_completion_response):
+def test_content_analysis_success(detection_base, completion_response):
     base_instance = asyncio.run(detection_base)
 
     content_request = ContentsDetectionRequest(
@@ -171,7 +171,7 @@ def test_content_analysis_success(detection_base, granite_completion_response):
     )
 
     scores = [0.9, 0.1, 0.21, 0.54, 0.33]
-    response = (granite_completion_response, scores, "risk")
+    response = (completion_response, scores, "risk")
     with patch(
         "vllm_detector_adapter.generative_detectors.base.ChatCompletionDetectionBase.process_chat_completion_with_scores",
         return_value=response,

--- a/tests/generative_detectors/test_base.py
+++ b/tests/generative_detectors/test_base.py
@@ -1,16 +1,31 @@
 # Standard
 from dataclasses import dataclass
 from typing import Optional
+from unittest.mock import patch
 import asyncio
 
 # Third Party
 from vllm.config import MultiModalConfig
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionLogProb,
+    ChatCompletionLogProbs,
+    ChatCompletionLogProbsContent,
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatMessage,
+    UsageInfo,
+)
 from vllm.entrypoints.openai.serving_models import BaseModelPath, OpenAIServingModels
 import jinja2
+import pytest
 import pytest_asyncio
 
 # Local
 from vllm_detector_adapter.generative_detectors.base import ChatCompletionDetectionBase
+from vllm_detector_adapter.protocol import (
+    ContentsDetectionRequest,
+    ContentsDetectionResponse,
+)
 
 MODEL_NAME = "openai-community/gpt2"
 CHAT_TEMPLATE = "Dummy chat template for testing {}"
@@ -82,6 +97,55 @@ async def detection_base():
     return _async_serving_detection_completion_init()
 
 
+@pytest.fixture(scope="module")
+def granite_completion_response():
+    log_probs_content_no = ChatCompletionLogProbsContent(
+        token="no",
+        logprob=-0.0013,
+        # 5 logprobs requested for scoring, skipping bytes for conciseness
+        top_logprobs=[
+            ChatCompletionLogProb(token="no", logprob=-0.053),
+            ChatCompletionLogProb(token="0", logprob=-6.61),
+            ChatCompletionLogProb(token="1", logprob=-16.90),
+            ChatCompletionLogProb(token="2", logprob=-17.39),
+            ChatCompletionLogProb(token="3", logprob=-17.61),
+        ],
+    )
+    log_probs_content_yes = ChatCompletionLogProbsContent(
+        token="yes",
+        logprob=-0.0013,
+        # 5 logprobs requested for scoring, skipping bytes for conciseness
+        top_logprobs=[
+            ChatCompletionLogProb(token="yes", logprob=-0.0013),
+            ChatCompletionLogProb(token="0", logprob=-6.61),
+            ChatCompletionLogProb(token="1", logprob=-16.90),
+            ChatCompletionLogProb(token="2", logprob=-17.39),
+            ChatCompletionLogProb(token="3", logprob=-17.61),
+        ],
+    )
+    choice_0 = ChatCompletionResponseChoice(
+        index=0,
+        message=ChatMessage(
+            role="assistant",
+            content="no",
+        ),
+        logprobs=ChatCompletionLogProbs(content=[log_probs_content_no]),
+    )
+    choice_1 = ChatCompletionResponseChoice(
+        index=1,
+        message=ChatMessage(
+            role="assistant",
+            content="yes",
+        ),
+        logprobs=ChatCompletionLogProbs(content=[log_probs_content_yes]),
+    )
+    yield ChatCompletionResponse(
+        model=MODEL_NAME,
+        choices=[choice_0, choice_1],
+        usage=UsageInfo(prompt_tokens=200, total_tokens=206, completion_tokens=6),
+    )
+
+
 ### Tests #####################################################################
 
 
@@ -97,3 +161,39 @@ def test_async_serving_detection_completion_init(detection_base):
     output_template = detection_completion.output_template
     assert type(output_template) == jinja2.environment.Template
     assert output_template.render(({"text": "moose"})) == "bye moose"
+
+
+def test_content_analysis_success(detection_base, granite_completion_response):
+    base_instance = asyncio.run(detection_base)
+
+    content_request = ContentsDetectionRequest(
+        contents=["Where do I find geese?", "You could go to Canada"]
+    )
+
+    scores = [0.9, 0.1, 0.21, 0.54, 0.33]
+    response = (granite_completion_response, scores, "risk")
+    with patch(
+        "vllm_detector_adapter.generative_detectors.base.ChatCompletionDetectionBase.process_chat_completion_with_scores",
+        return_value=response,
+    ):
+        result = asyncio.run(base_instance.content_analysis(content_request))
+        assert isinstance(result, ContentsDetectionResponse)
+        detections = result.model_dump()
+        assert len(detections) == 2
+        print(detections)
+        # For first content
+        assert detections[0][0]["detection"] == "no"
+        assert detections[0][0]["score"] == 0.9
+        assert detections[0][0]["start"] == 0
+        assert detections[0][0]["end"] == len(content_request.contents[0])
+        # 2nd choice as 2nd label
+        assert detections[0][1]["detection"] == "yes"
+        assert detections[0][1]["score"] == 0.1
+        assert detections[0][1]["start"] == 0
+        assert detections[0][1]["end"] == len(content_request.contents[0])
+        # For 2nd content, we are only testing 1st detection for simplicity
+        # Note: detection is same, because of how mock is working.
+        assert detections[1][0]["detection"] == "no"
+        assert detections[1][0]["score"] == 0.9
+        assert detections[1][0]["start"] == 0
+        assert detections[1][0]["end"] == len(content_request.contents[1])

--- a/tests/generative_detectors/test_llama_guard.py
+++ b/tests/generative_detectors/test_llama_guard.py
@@ -25,6 +25,8 @@ import pytest_asyncio
 from vllm_detector_adapter.generative_detectors.llama_guard import LlamaGuard
 from vllm_detector_adapter.protocol import (
     ChatDetectionRequest,
+    ContentsDetectionRequest,
+    ContentsDetectionResponse,
     ContextAnalysisRequest,
     DetectionChatMessageParam,
     DetectionResponse,
@@ -213,3 +215,93 @@ def test_context_analyze(llama_guard_detection):
     )
     assert type(response) == ErrorResponse
     assert response.code == HTTPStatus.NOT_IMPLEMENTED
+
+
+def test_post_process_content_splits_usafe_categories(llama_guard_detection):
+    unsafe_message = "\n\nunsafe\nS2,S3"
+    responses = ChatCompletionResponse(
+        model="foo",
+        usage=UsageInfo(prompt_tokens=1, total_tokens=1),
+        choices=[
+            ChatCompletionResponseChoice(
+                index=1,
+                message=ChatMessage(
+                    content=unsafe_message,
+                    role=" assistant",
+                ),
+            )
+        ],
+    )
+    unsafe_score = 0.99
+    llama_guard_detection_instance = asyncio.run(llama_guard_detection)
+    # NOTE: we are testing private function here
+    (
+        responses,
+        scores,
+        _,
+    ) = llama_guard_detection_instance._LlamaGuard__post_process_result(
+        responses, [unsafe_score], "risk"
+    )
+    assert isinstance(responses, ChatCompletionResponse)
+    assert responses.choices[0].message.content == "unsafe"
+    assert scores[0] == unsafe_score
+    assert responses.choices[1].message.content == "S2"
+    # NOTE: currently we expect same score for each category
+    assert scores[1] == unsafe_score
+    assert responses.choices[2].message.content == "S3"
+    assert scores[2] == unsafe_score
+
+
+def test_post_process_content_works_for_safe(llama_guard_detection):
+    safe_message = "safe"
+    responses = ChatCompletionResponse(
+        model="foo",
+        usage=UsageInfo(prompt_tokens=1, total_tokens=1),
+        choices=[
+            ChatCompletionResponseChoice(
+                index=1,
+                message=ChatMessage(
+                    content=safe_message,
+                    role=" assistant",
+                ),
+            )
+        ],
+    )
+    safe_message = 0.99
+    llama_guard_detection_instance = asyncio.run(llama_guard_detection)
+    # NOTE: we are testing private function here
+    (
+        responses,
+        scores,
+        _,
+    ) = llama_guard_detection_instance._LlamaGuard__post_process_result(
+        responses, [safe_message], "risk"
+    )
+    assert isinstance(responses, ChatCompletionResponse)
+    assert len(responses.choices) == 1
+    assert responses.choices[0].message.content == "safe"
+    assert scores[0] == safe_message
+
+
+def test_content_detection_with_llama_guard(
+    llama_guard_detection, llama_guard_completion_response
+):
+    llama_guard_detection_instance = asyncio.run(llama_guard_detection)
+    content_request = ContentsDetectionRequest(
+        contents=["Where do I find geese?", "You could go to Canada"]
+    )
+    with patch(
+        "vllm_detector_adapter.generative_detectors.llama_guard.LlamaGuard.create_chat_completion",
+        return_value=llama_guard_completion_response,
+    ):
+        detection_response = asyncio.run(
+            llama_guard_detection_instance.content_analysis(content_request)
+        )
+        assert type(detection_response) == ContentsDetectionResponse
+        detections = detection_response.model_dump()
+        assert len(detections) == 2  # 2 contents in the request
+        assert len(detections[0]) == 2  # 2 choices
+        detection_0 = detections[0][0]  # for 1st text in request
+        assert detection_0["detection"] == "safe"
+        assert detection_0["detection_type"] == "risk"
+        assert pytest.approx(detection_0["score"]) == 0.001346767

--- a/tests/generative_detectors/test_llama_guard.py
+++ b/tests/generative_detectors/test_llama_guard.py
@@ -217,7 +217,7 @@ def test_context_analyze(llama_guard_detection):
     assert response.code == HTTPStatus.NOT_IMPLEMENTED
 
 
-def test_post_process_content_splits_usafe_categories(llama_guard_detection):
+def test_post_process_content_splits_unsafe_categories(llama_guard_detection):
     unsafe_message = "\n\nunsafe\nS2,S3"
     responses = ChatCompletionResponse(
         model="foo",
@@ -267,7 +267,7 @@ def test_post_process_content_works_for_safe(llama_guard_detection):
             )
         ],
     )
-    safe_message = 0.99
+    safe_score = 0.99
     llama_guard_detection_instance = asyncio.run(llama_guard_detection)
     # NOTE: we are testing private function here
     (

--- a/tests/generative_detectors/test_llama_guard.py
+++ b/tests/generative_detectors/test_llama_guard.py
@@ -219,7 +219,7 @@ def test_context_analyze(llama_guard_detection):
 
 def test_post_process_content_splits_unsafe_categories(llama_guard_detection):
     unsafe_message = "\n\nunsafe\nS2,S3"
-    responses = ChatCompletionResponse(
+    response = ChatCompletionResponse(
         model="foo",
         usage=UsageInfo(prompt_tokens=1, total_tokens=1),
         choices=[
@@ -236,21 +236,21 @@ def test_post_process_content_splits_unsafe_categories(llama_guard_detection):
     llama_guard_detection_instance = asyncio.run(llama_guard_detection)
     # NOTE: we are testing private function here
     (
-        responses,
+        response,
         scores,
         _,
     ) = llama_guard_detection_instance._LlamaGuard__post_process_result(
-        responses, [unsafe_score], "risk"
+        response, [unsafe_score], "risk"
     )
-    assert isinstance(responses, ChatCompletionResponse)
-    assert responses.choices[0].message.content == "unsafe"
+    assert isinstance(response, ChatCompletionResponse)
+    assert response.choices[0].message.content == "unsafe"
     assert scores[0] == unsafe_score
-    assert len(responses.choices) == 1
+    assert len(response.choices) == 1
 
 
 def test_post_process_content_works_for_safe(llama_guard_detection):
     safe_message = "safe"
-    responses = ChatCompletionResponse(
+    response = ChatCompletionResponse(
         model="foo",
         usage=UsageInfo(prompt_tokens=1, total_tokens=1),
         choices=[
@@ -267,16 +267,17 @@ def test_post_process_content_works_for_safe(llama_guard_detection):
     llama_guard_detection_instance = asyncio.run(llama_guard_detection)
     # NOTE: we are testing private function here
     (
-        responses,
+        response,
         scores,
         _,
     ) = llama_guard_detection_instance._LlamaGuard__post_process_result(
-        responses, [safe_message], "risk"
+        response, [safe_score], "risk"
     )
-    assert isinstance(responses, ChatCompletionResponse)
-    assert len(responses.choices) == 1
-    assert responses.choices[0].message.content == "safe"
-    assert scores[0] == safe_message
+
+    assert isinstance(response, ChatCompletionResponse)
+    assert len(response.choices) == 1
+    assert response.choices[0].message.content == "safe"
+    assert scores[0] == safe_score
 
 
 def test_content_detection_with_llama_guard(

--- a/tests/generative_detectors/test_llama_guard.py
+++ b/tests/generative_detectors/test_llama_guard.py
@@ -245,11 +245,7 @@ def test_post_process_content_splits_unsafe_categories(llama_guard_detection):
     assert isinstance(responses, ChatCompletionResponse)
     assert responses.choices[0].message.content == "unsafe"
     assert scores[0] == unsafe_score
-    assert responses.choices[1].message.content == "S2"
-    # NOTE: currently we expect same score for each category
-    assert scores[1] == unsafe_score
-    assert responses.choices[2].message.content == "S3"
-    assert scores[2] == unsafe_score
+    assert len(responses.choices) == 1
 
 
 def test_post_process_content_works_for_safe(llama_guard_detection):

--- a/vllm_detector_adapter/api_server.py
+++ b/vllm_detector_adapter/api_server.py
@@ -27,6 +27,8 @@ from vllm_detector_adapter import generative_detectors
 from vllm_detector_adapter.logging import init_logger
 from vllm_detector_adapter.protocol import (
     ChatDetectionRequest,
+    ContentsDetectionRequest,
+    ContentsDetectionResponse,
     ContextAnalysisRequest,
     DetectionResponse,
 )
@@ -183,6 +185,28 @@ async def create_context_doc_detection(
         )
 
     elif isinstance(detector_response, DetectionResponse):
+        return JSONResponse(content=detector_response.model_dump())
+
+    return JSONResponse({})
+
+
+@router.post("/api/v1/text/contents")
+async def create_contents_detection(
+    request: ContentsDetectionRequest, raw_request: Request
+):
+    """Support content analysis endpoint"""
+
+    detector_response = await chat_detection(raw_request).content_analysis(
+        request, raw_request
+    )
+    print("detector_response: ", detector_response)
+    if isinstance(detector_response, ErrorResponse):
+        # ErrorResponse includes code and message, corresponding to errors for the detectorAPI
+        return JSONResponse(
+            content=detector_response.model_dump(), status_code=detector_response.code
+        )
+
+    elif isinstance(detector_response, list):
         return JSONResponse(content=detector_response.model_dump())
 
     return JSONResponse({})

--- a/vllm_detector_adapter/api_server.py
+++ b/vllm_detector_adapter/api_server.py
@@ -199,14 +199,13 @@ async def create_contents_detection(
     detector_response = await chat_detection(raw_request).content_analysis(
         request, raw_request
     )
-    print("detector_response: ", detector_response)
     if isinstance(detector_response, ErrorResponse):
         # ErrorResponse includes code and message, corresponding to errors for the detectorAPI
         return JSONResponse(
             content=detector_response.model_dump(), status_code=detector_response.code
         )
 
-    elif isinstance(detector_response, list):
+    elif isinstance(detector_response, ContentsDetectionResponse):
         return JSONResponse(content=detector_response.model_dump())
 
     return JSONResponse({})

--- a/vllm_detector_adapter/generative_detectors/base.py
+++ b/vllm_detector_adapter/generative_detectors/base.py
@@ -1,14 +1,18 @@
 # Standard
 from http import HTTPStatus
 from pathlib import Path
-from typing import Awaitable, List, Optional, Union
+from typing import List, Optional, Union
 import asyncio
 import codecs
 import math
 
 # Third Party
 from fastapi import Request
-from vllm.entrypoints.openai.protocol import ChatCompletionRequest, ChatCompletionResponse, ErrorResponse
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ErrorResponse,
+)
 from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
 import jinja2
 import torch
@@ -17,12 +21,12 @@ import torch
 from vllm_detector_adapter.detector_dispatcher import detector_dispatcher
 from vllm_detector_adapter.logging import init_logger
 from vllm_detector_adapter.protocol import (
+    ROLE_OVERRIDE_PARAM_NAME,
     ChatDetectionRequest,
     ContentsDetectionRequest,
     ContentsDetectionResponse,
     ContextAnalysisRequest,
     DetectionResponse,
-    ROLE_OVERRIDE_PARAM_NAME,
 )
 from vllm_detector_adapter.utils import DetectorType
 
@@ -98,20 +102,21 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
         return request
 
     @detector_dispatcher(types=[DetectorType.TEXT_CHAT])
-    def preprocess_request(
+    def preprocess_request( # noqa: F811
         self, request: ChatDetectionRequest
     ) -> Union[ChatDetectionRequest, ErrorResponse]:
         """Preprocess chat request"""
+        # pylint: disable=redefined-outer-name
         return request
 
     ##### Contents request processing functions ####################################
 
     @detector_dispatcher(types=[DetectorType.TEXT_CONTENT])
-    def preprocess_request(
+    def preprocess_request( # noqa: F811
         self, request: ContentsDetectionRequest
     ) -> Union[ContentsDetectionRequest, ErrorResponse]:
         """Preprocess contents request and convert it into appropriate chat request"""
-
+        # pylint: disable=redefined-outer-name
         # Fetch model name from super class: OpenAIServing
         model_name = self.models.base_model_paths[0].name
 
@@ -311,12 +316,5 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
             # and not every or not cumulative
             if isinstance(result, ErrorResponse):
                 return result
-        import pprint
-        pprint.pprint(results)
-        return [
-            ContentsDetectionResponse.from_chat_completion_response(
-                chat_response, scores, detection_type
-            )
-            for (chat_response, scores, detection_type) in results
-        ]
 
+        return ContentsDetectionResponse.from_chat_completion_response(results)

--- a/vllm_detector_adapter/generative_detectors/base.py
+++ b/vllm_detector_adapter/generative_detectors/base.py
@@ -115,8 +115,8 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
     @detector_dispatcher(types=[DetectorType.TEXT_CONTENT])
     def preprocess_request(  # noqa: F811
         self, request: ContentsDetectionRequest
-    ) -> Union[ContentsDetectionRequest, ErrorResponse]:
-        """Preprocess contents request and convert it into appropriate chat request"""
+    ) -> Union[List[ChatCompletionRequest], ErrorResponse]:
+        """Preprocess contents request and convert it into appropriate chat requests"""
         # pylint: disable=redefined-outer-name
         # Fetch model name from super class: OpenAIServing
         model_name = self.models.base_model_paths[0].name
@@ -289,7 +289,7 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
         self,
         request: ContentsDetectionRequest,
         raw_request: Optional[Request] = None,
-    ):
+    ) -> Union[ContentsDetectionResponse, ErrorResponse]:
         """Function used to call chat detection and provide a /text/contents response"""
 
         # Apply task template if it exists

--- a/vllm_detector_adapter/generative_detectors/base.py
+++ b/vllm_detector_adapter/generative_detectors/base.py
@@ -102,7 +102,7 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
         return request
 
     @detector_dispatcher(types=[DetectorType.TEXT_CHAT])
-    def preprocess_request( # noqa: F811
+    def preprocess_request(  # noqa: F811
         self, request: ChatDetectionRequest
     ) -> Union[ChatDetectionRequest, ErrorResponse]:
         """Preprocess chat request"""
@@ -112,7 +112,7 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
     ##### Contents request processing functions ####################################
 
     @detector_dispatcher(types=[DetectorType.TEXT_CONTENT])
-    def preprocess_request( # noqa: F811
+    def preprocess_request(  # noqa: F811
         self, request: ContentsDetectionRequest
     ) -> Union[ContentsDetectionRequest, ErrorResponse]:
         """Preprocess contents request and convert it into appropriate chat request"""

--- a/vllm_detector_adapter/generative_detectors/base.py
+++ b/vllm_detector_adapter/generative_detectors/base.py
@@ -122,7 +122,7 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
         model_name = self.models.base_model_paths[0].name
 
         # Fetch role override from detector_params, otherwise use default
-        role = request.detector_params.get(
+        role = request.detector_params.pop(
             ROLE_OVERRIDE_PARAM_NAME, DEFAULT_ROLE_FOR_CONTENTS_DETECTION
         )
 

--- a/vllm_detector_adapter/generative_detectors/base.py
+++ b/vllm_detector_adapter/generative_detectors/base.py
@@ -1,7 +1,7 @@
 # Standard
 from http import HTTPStatus
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 import asyncio
 import codecs
 import math
@@ -173,7 +173,7 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
 
     async def process_chat_completion_with_scores(
         self, chat_completion_request, raw_request
-    ) -> Union[DetectionResponse, ErrorResponse]:
+    ) -> Union[Tuple[ChatCompletionResponse, List[float], str], ErrorResponse]:
         # Return an error for streaming for now. Since the detector API is unary,
         # results would not be streamed back anyway. The chat completion response
         # object would look different, and content would have to be aggregated.

--- a/vllm_detector_adapter/generative_detectors/base.py
+++ b/vllm_detector_adapter/generative_detectors/base.py
@@ -333,4 +333,6 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
             if isinstance(result, ErrorResponse):
                 return result
 
-        return ContentsDetectionResponse.from_chat_completion_response(results)
+        return ContentsDetectionResponse.from_chat_completion_response(
+            results, request.contents
+        )

--- a/vllm_detector_adapter/generative_detectors/granite_guardian.py
+++ b/vllm_detector_adapter/generative_detectors/granite_guardian.py
@@ -178,6 +178,16 @@ class GraniteGuardian(ChatCompletionDetectionBase):
 
         # Calling chat completion and processing of scores is currently
         # the same as for the /chat case
-        return await self.process_chat_completion_with_scores(
+        result = await self.process_chat_completion_with_scores(
             chat_completion_request, raw_request
+        )
+
+        if isinstance(result, ErrorResponse):
+            # Propagate any errors from OpenAI API
+            return result
+        else:
+            (chat_response, scores, detection_type) = result
+
+        return DetectionResponse.from_chat_completion_response(
+            chat_response, scores, detection_type
         )

--- a/vllm_detector_adapter/generative_detectors/llama_guard.py
+++ b/vllm_detector_adapter/generative_detectors/llama_guard.py
@@ -1,6 +1,20 @@
+# Standard
+from typing import Optional
+import asyncio
+import copy
+
+# Third Party
+from fastapi import Request
+from vllm.entrypoints.openai.protocol import ErrorResponse
+
 # Local
 from vllm_detector_adapter.generative_detectors.base import ChatCompletionDetectionBase
 from vllm_detector_adapter.logging import init_logger
+from vllm_detector_adapter.protocol import (
+    ContentsDetectionRequest,
+    ContentsDetectionResponse,
+)
+from vllm_detector_adapter.utils import DetectorType
 
 logger = init_logger(__name__)
 
@@ -13,5 +27,100 @@ class LlamaGuard(ChatCompletionDetectionBase):
     SAFE_TOKEN = "safe"
     UNSAFE_TOKEN = "unsafe"
 
-    # NOTE: More intelligent template parsing can be done here, potentially
-    # as a regex template for safe vs. unsafe and the 'unsafe' category
+    def __post_process_results(self, results):
+        # NOTE: Llama-guard returns specific safety categories in the last line and in a csv format
+        # this is guided by the prompt definition of the model, so we expect llama_guard to adhere to it
+        # atleast for Llama-Guard-3 (latest at the time of writing)
+
+        # NOTE: The concept of "choice" doesn't exist for content type detector API, so
+        # we will essentially flatten out the responses, so different categories in 1 choice
+        # will also look like another choice.
+
+        (responses, scores, detection_type) = results
+
+        new_choices = []
+        new_scores = []
+
+        for i, choice in enumerate(responses.choices):
+            content = choice.message.content
+            if self.UNSAFE_TOKEN in content:
+                # We will create multiple results for each unsafe category
+                # in addition to "unsafe" as a category itself
+                # NOTE: need to deepcopy, otherwise, choice will get overwritten
+                unsafe_choice = copy.deepcopy(choice)
+                unsafe_choice.message.content = self.UNSAFE_TOKEN
+
+                new_choices.append(unsafe_choice)
+                new_scores.append(scores[i])
+
+                # Fetch categories as the last line in the response available in csv format
+                for category in content.strip().split("\n")[-1].split(","):
+                    category_choice = copy.deepcopy(choice)
+                    category_choice.message.content = category
+                    new_choices.append(category_choice)
+                    # NOTE: currently using same score as "unsafe"
+                    # but we need to see if we can revisit this to get better score
+                    new_scores.append(scores[i])
+            else:
+                # "safe" case
+                new_choices.append(choice)
+                new_scores.append(scores[i])
+
+        responses.choices = new_choices
+        return (responses, new_scores, detection_type)
+
+    async def content_analysis(
+        self,
+        request: ContentsDetectionRequest,
+        raw_request: Optional[Request] = None,
+    ):
+        """Function used to call chat detection and provide a /text/contents response"""
+
+        # Apply task template if it exists
+        if self.task_template:
+            request = self.apply_task_template(
+                request, fn_type=DetectorType.TEXT_CONTENT
+            )
+            if isinstance(request, ErrorResponse):
+                # Propagate any request problems that will not allow
+                # task template to be applied
+                return request
+
+        # Since separate batch processing function doesn't exist at the time of writing,
+        # we are just going to collect all the text from content request and fire up
+        # separate requests and wait asynchronously.
+        # This mirrors how batching is handled in run_batch function in entrypoints/openai/
+        # in vLLM codebase.
+        completion_requests = self.preprocess_request(
+            request, fn_type=DetectorType.TEXT_CONTENT
+        )
+
+        # Send all the completion requests asynchronously.
+        tasks = [
+            asyncio.create_task(
+                self.process_chat_completion_with_scores(
+                    completion_request, raw_request
+                )
+            )
+            for completion_request in completion_requests
+        ]
+
+        # Gather all the results
+        # NOTE: The results are guaranteed to be in order of requests
+        results = await asyncio.gather(*tasks)
+
+        # If there is any error, return that otherwise, return the whole response
+        # properly formatted.
+        categorized_results = []
+        for result in results:
+            # NOTE: we are only sending 1 of the error results
+            # and not every or not cumulative
+            if isinstance(result, ErrorResponse):
+                return result
+            else:
+                # Process results to split out safety categories into separate objects
+                categorized_results.append(self.__post_process_results(result))
+
+        return ContentsDetectionResponse.from_chat_completion_response(
+            categorized_results, request.contents
+        )

--- a/vllm_detector_adapter/generative_detectors/llama_guard.py
+++ b/vllm_detector_adapter/generative_detectors/llama_guard.py
@@ -112,7 +112,7 @@ class LlamaGuard(ChatCompletionDetectionBase):
         processed_result = []
         for result in results:
             # NOTE: we are only sending 1 of the error results
-            # and not every or not cumulative
+            # and not every one (not cumulative)
             if isinstance(result, ErrorResponse):
                 return result
             else:

--- a/vllm_detector_adapter/generative_detectors/llama_guard.py
+++ b/vllm_detector_adapter/generative_detectors/llama_guard.py
@@ -26,16 +26,16 @@ class LlamaGuard(ChatCompletionDetectionBase):
     SAFE_TOKEN = "safe"
     UNSAFE_TOKEN = "unsafe"
 
-    def __post_process_result(self, responses, scores, detection_type):
+    def __post_process_result(self, response, scores, detection_type):
         """Function to process chat completion results for content type detection.
 
         Args:
-            responses: ChatCompletionResponse,
+            response: ChatCompletionResponse,
             scores: List[float],
             detection_type: str,
         Returns:
             Tuple(
-                responses: ChatCompletionResponse,
+                response: ChatCompletionResponse,
                 scores: List[float],
                 detection_type,
             )
@@ -51,7 +51,7 @@ class LlamaGuard(ChatCompletionDetectionBase):
         new_scores = []
 
         # NOTE: we are flattening out choices here as different categories
-        for i, choice in enumerate(responses.choices):
+        for i, choice in enumerate(response.choices):
             content = choice.message.content
             if self.UNSAFE_TOKEN in content:
                 # Reason for reassigning the content:
@@ -64,8 +64,8 @@ class LlamaGuard(ChatCompletionDetectionBase):
                 new_choices.append(choice)
                 new_scores.append(scores[i])
 
-        responses.choices = new_choices
-        return (responses, new_scores, detection_type)
+        response.choices = new_choices
+        return (response, new_scores, detection_type)
 
     async def content_analysis(
         self,

--- a/vllm_detector_adapter/generative_detectors/llama_guard.py
+++ b/vllm_detector_adapter/generative_detectors/llama_guard.py
@@ -54,7 +54,7 @@ class LlamaGuard(ChatCompletionDetectionBase):
                 new_scores.append(scores[i])
 
                 # Fetch categories as the last line in the response available in csv format
-                for category in content.strip().split("\n")[-1].split(","):
+                for category in content.splitlines()[-1].split(","):
                     category_choice = copy.deepcopy(choice)
                     category_choice.message.content = category
                     new_choices.append(category_choice)

--- a/vllm_detector_adapter/protocol.py
+++ b/vllm_detector_adapter/protocol.py
@@ -53,7 +53,7 @@ class ContentsDetectionResponse(RootModel):
 
         Args:
             results: List(Tuple(
-                responses: ChatCompletionResponse,
+                response: ChatCompletionResponse,
                 scores: List[float],
                 detection_type,
             ))
@@ -62,13 +62,13 @@ class ContentsDetectionResponse(RootModel):
         """
         contents_detection_responses = []
 
-        for content_idx, (responses, scores, detection_type) in enumerate(results):
+        for content_idx, (response, scores, detection_type) in enumerate(results):
 
             detection_responses = []
             start = 0
             end = len(contents[content_idx])
 
-            for i, choice in enumerate(responses.choices):
+            for i, choice in enumerate(response.choices):
                 content = choice.message.content
                 # NOTE: for providing spans, we currently consider entire generated text as a span.
                 # This is because, at the time of writing, the generative guardrail models does not

--- a/vllm_detector_adapter/protocol.py
+++ b/vllm_detector_adapter/protocol.py
@@ -70,7 +70,7 @@ class ContentsDetectionResponse(RootModel):
                 content = choice.message.content
                 # NOTE: for providing spans, we currently consider entire generated text as a span.
                 # This is because, at the time of writing, the generative guardrail models does not
-                # provide spefific information about input text, which can be used to deduce spans.
+                # provide specific information about input text, which can be used to deduce spans.
                 if content and isinstance(content, str):
                     response_object = ContentsDetectionResponseObject(
                         detection_type=detection_type,

--- a/vllm_detector_adapter/protocol.py
+++ b/vllm_detector_adapter/protocol.py
@@ -57,6 +57,8 @@ class ContentsDetectionResponse(RootModel):
                 scores: List[float],
                 detection_type,
             ))
+            contents: List[str]
+               List of contents in the request
         """
         contents_detection_responses = []
 

--- a/vllm_detector_adapter/protocol.py
+++ b/vllm_detector_adapter/protocol.py
@@ -27,7 +27,7 @@ class ContentsDetectionRequest(BaseModel):
         ]
     )
     # Parameter passthrough
-    # NOTE: this server does support optional, `role_override`` parameter
+    # NOTE: this endpoint does support the optional `role_override` parameter
     # which allows use of different role when making a call to the guardrails LLM
     # via chat/completions
     detector_params: Optional[Dict] = {}

--- a/vllm_detector_adapter/protocol.py
+++ b/vllm_detector_adapter/protocol.py
@@ -45,45 +45,60 @@ class ContentsDetectionResponseObject(BaseModel):
 class ContentsDetectionResponse(RootModel):
     # The root attribute is used here so that the response will appear
     # as a list instead of a list nested under a key
-    root: List[ContentsDetectionResponseObject]
+    root: List[List[ContentsDetectionResponseObject]]
 
     @staticmethod
     def from_chat_completion_response(
-        responses: ChatCompletionResponse, scores: List[float], detection_type: str
+        results,
+        # responses: ChatCompletionResponse, scores: List[float], detection_type: str
     ):
-        """Function to convert openai chat completion response to [fms] contents detection response"""
-        detection_responses = []
-        for i, choice in enumerate(response.choices):
-            content = choice.message.content
-            print("content: ", content)
-            # NOTE: for providing spans, we currently consider entire generated text as a span.
-            # This is because, at the time of writing, the generative guardrail models does not
-            # provide spefific information about text, which can be used to deduce spans.
-            start = 0
-            end = len(content)
-            if content and isinstance(content, str):
-                response_object = ContentsDetectionResponseObject(
-                    detection_type=detection_type,
-                    detection=content.strip(),
-                    start=start,
-                    end=end,
-                    text=content,
-                    score=scores[i],
-                ).model_dump()
-                detection_responses.append(response_object)
-            else:
-                # This case should be unlikely but we handle it since a detection
-                # can't be returned without the content
-                # A partial response could be considered in the future
-                # but that would likely not look like the current ErrorResponse
-                return ErrorResponse(
-                    message=f"Choice {i} from chat completion does not have content. \
-                        Consider updating input and/or parameters for detections.",
-                    type="BadRequestError",
-                    code=HTTPStatus.BAD_REQUEST.value,
-                )
+        """Function to convert openai chat completion response to [fms] contents detection response
 
-        return ContentsDetectionResponse(root=detection_responses)
+        Args:
+            results: List(Tuple(
+                responses: ChatCompletionResponse,
+                scores: List[float],
+                detection_type,
+            ))
+        """
+        contents_detection_responses = []
+
+        for (responses, scores, detection_type) in results:
+
+            detection_responses = []
+            for i, choice in enumerate(responses.choices):
+                content = choice.message.content
+                # NOTE: for providing spans, we currently consider entire generated text as a span.
+                # This is because, at the time of writing, the generative guardrail models does not
+                # provide spefific information about text, which can be used to deduce spans.
+                start = 0
+                end = len(content)
+                if content and isinstance(content, str):
+                    response_object = ContentsDetectionResponseObject(
+                        detection_type=detection_type,
+                        detection=content.strip(),
+                        start=start,
+                        end=end,
+                        text=content,
+                        score=scores[i],
+                    ).model_dump()
+                    detection_responses.append(response_object)
+                else:
+                    # This case should be unlikely but we handle it since a detection
+                    # can't be returned without the content
+                    # A partial response could be considered in the future
+                    # but that would likely not look like the current ErrorResponse
+                    return ErrorResponse(
+                        message=f"Choice {i} from chat completion does not have content. \
+                            Consider updating input and/or parameters for detections.",
+                        type="BadRequestError",
+                        code=HTTPStatus.BAD_REQUEST.value,
+                    )
+
+            # return ContentsDetectionResponse(root=detection_responses)
+            contents_detection_responses.append(detection_responses)
+
+        return ContentsDetectionResponse(root=contents_detection_responses)
 
 
 ##### Chat Detection types for the /text/chat detection endpoint ###############

--- a/vllm_detector_adapter/protocol.py
+++ b/vllm_detector_adapter/protocol.py
@@ -63,13 +63,14 @@ class ContentsDetectionResponse(RootModel):
         for content_idx, (responses, scores, detection_type) in enumerate(results):
 
             detection_responses = []
+            start = 0
+            end = len(contents[content_idx])
+
             for i, choice in enumerate(responses.choices):
                 content = choice.message.content
                 # NOTE: for providing spans, we currently consider entire generated text as a span.
                 # This is because, at the time of writing, the generative guardrail models does not
                 # provide spefific information about input text, which can be used to deduce spans.
-                start = 0
-                end = len(contents[content_idx])
                 if content and isinstance(content, str):
                     response_object = ContentsDetectionResponseObject(
                         detection_type=detection_type,


### PR DESCRIPTION
## Changes

- Add support for "content type" detector endpoint running on top of generative guardrail models.


## Examples

### Request (Llama-guard)
```bash
curl -X 'POST'   'http://localhost:8000/api/v1/text/contents' -H 'accept: application/json'   -H 'detector-id: llama-guard'   -H 'Content-Type: application/json'   -d '{ "contents": ["If you are thinking about skipping out on filing your taxes, there are a few ways to avoid getting caught.", "this is a fairly good sentence."], "detector_params": {}}'
```

Note: above sentence taken from dataset examples of llama-guard

### Response
```bash
[
   [
      {
         "detection" : "unsafe",
         "detection_type" : "risk",
         "end" : 106,
         "score" : 0.531209409236908,
         "start" : 0,
         "text" : "If you are thinking about skipping out on filing your taxes, there are a few ways to avoid getting caught."
      }
   ],
   [
      {
         "detection" : "safe",
         "detection_type" : "risk",
         "end" : 31,
         "score" : 0.00359360268339515,
         "start" : 0,
         "text" : "this is a fairly good sentence."
      }
   ]
]
```
