### PR TITLE
Update tgis adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 
 [project.optional-dependencies]
 vllm-tgis-adapter = [
-    "vllm-tgis-adapter>=0.5.3,<0.5.4"
+    "vllm-tgis-adapter>=0.6.2,<0.6.3"
 ]
 
 ## Dev Extra Sets ##

--- a/vllm_detector_adapter/start_with_tgis_adapter.py
+++ b/vllm_detector_adapter/start_with_tgis_adapter.py
@@ -52,6 +52,7 @@ else:
         add_tgis_args,
         postprocess_tgis_args,
     )
+    from vllm_tgis_adapter.tgis_utils.logs import add_logging_wrappers
     from vllm_tgis_adapter.utils import check_for_failed_tasks, write_termination_log
 
 # Note: this function references run_http_server in
@@ -66,7 +67,7 @@ async def run_http_server(
 
     app = api_server.build_app(args)
     model_config = await engine.get_model_config()
-    init_app_state_with_detectors(engine, model_config, app.state, args)
+    await init_app_state_with_detectors(engine, model_config, app.state, args)
 
     serve_kwargs = {
         "host": args.host,
@@ -95,6 +96,8 @@ async def start_servers(args: argparse.Namespace) -> None:
 
     tasks: list[asyncio.Task] = []
     async with api_server.build_async_engine_client(args) as engine:
+        add_logging_wrappers(engine)
+
         http_server_task = loop.create_task(
             run_http_server(args, engine),
             name="http_server",

--- a/vllm_detector_adapter/start_with_tgis_adapter.py
+++ b/vllm_detector_adapter/start_with_tgis_adapter.py
@@ -35,7 +35,7 @@ from vllm_detector_adapter.api_server import (
 from vllm_detector_adapter.logging import init_logger
 
 TIMEOUT_KEEP_ALIVE = 5
-TGIS_ADAPTER_LIBRARY_NAME = "vllm-tgis-adapter"
+TGIS_ADAPTER_LIBRARY_NAME = "vllm_tgis_adapter"
 
 logger = init_logger("vllm_detector_adapter.start_with_tgis_adapter")
 


### PR DESCRIPTION
Closes: https://github.com/foundation-model-stack/vllm-detector-adapter/issues/23

### Changes
- Fixes lib name for import time validation
- Update `vllm-tgis-adapter` to latest
- Fix await for app initialization
- Add support for tgis-adapter's new logging method



### Test
1. Tested grpc server
2. Tested `/text/chat` endpoint added by this adapter.
3. All endpoints are getting listed successfully. Logs:

```
INFO 02-21 14:54:53 launcher.py:19] Available routes are:
INFO 02-21 14:54:53 launcher.py:27] Route: /openapi.json, Methods: GET, HEAD
INFO 02-21 14:54:53 launcher.py:27] Route: /docs, Methods: GET, HEAD
INFO 02-21 14:54:53 launcher.py:27] Route: /docs/oauth2-redirect, Methods: GET, HEAD
INFO 02-21 14:54:53 launcher.py:27] Route: /redoc, Methods: GET, HEAD
INFO 02-21 14:54:53 launcher.py:27] Route: /health, Methods: GET
INFO 02-21 14:54:53 launcher.py:27] Route: /ping, Methods: GET, POST
INFO 02-21 14:54:53 launcher.py:27] Route: /tokenize, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /detokenize, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /v1/models, Methods: GET
INFO 02-21 14:54:53 launcher.py:27] Route: /version, Methods: GET
INFO 02-21 14:54:53 launcher.py:27] Route: /v1/chat/completions, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /v1/completions, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /v1/embeddings, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /pooling, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /score, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /v1/score, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /rerank, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /v1/rerank, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /v2/rerank, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /invocations, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /api/v1/text/chat, Methods: POST
INFO 02-21 14:54:53 launcher.py:27] Route: /api/v1/text/context/doc, Methods: POST
WARNING 02-21 14:54:53 grpc_server.py:195] TGIS Metrics currently disabled in decoupled front-end mode, set DISABLE_FRONTEND_MULTIPROCESSING=True to enable
INFO:     Started server process [21141]
INFO:     Waiting for application startup.
INFO 02-21 14:54:53 grpc_server.py:946] gRPC Server started at 0.0.0.0:8033
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:3000 (Press CTRL+C to quit)
```