### PR TITLE
:package: Update vllm upper bound to 0.7.3 to disallow breaking changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 
 dependencies = [
     "vllm @ git+https://github.com/vllm-project/vllm.git@v0.7.1 ; sys_platform == 'darwin'",
-    "vllm>=0.7.1 ; sys_platform != 'darwin'",
+    "vllm>=0.7.0,<0.7.3 ; sys_platform != 'darwin'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Changes

- Set vllm upper bound to 0.7.2, since 0.7.3 (latest version) has some breaking changes