### PR TITLE
Fix issue with granite guardian not working and add unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vllm-detector-adapter"
-version = "0.0.1"
+version = "0.4.2"
 authors = [
   { name="Gaurav Kumbhat", email="kumbhat.gaurav@gmail.com" },
   { name="Evaline Ju", email="evaline.ju@ibm.com" },

--- a/tests/test_detector_dispatcher.py
+++ b/tests/test_detector_dispatcher.py
@@ -1,0 +1,93 @@
+
+# Standard
+import pytest
+
+# Local
+from vllm_detector_adapter.detector_dispatcher import detector_dispatcher
+
+
+### Global Declarations ########################################################
+
+@detector_dispatcher(types=["foo"])
+def add(data):
+    return data + 1
+
+@detector_dispatcher(types=["bar"])
+def add(data):
+    return str(data) + " 1"
+
+@detector_dispatcher(types=["foo", "bar"])
+def diff(data):
+    return data - 1
+
+
+class Foo():
+    def __init__(self, x):
+        self.x = x
+
+    @detector_dispatcher(types=["foo"])
+    def add(self, data):
+        return data + 2
+
+    @detector_dispatcher(types=["bar"])
+    def add(self, data):
+        return str(data) + " 2"
+
+### Tests #####################################################################
+
+def test_detector_dispatching_to_module_functions():
+    "Test that correct function gets called when each are of different type"
+    assert add(1, fn_type="foo") == 2
+    assert add(1, fn_type="bar") == "1 1"
+
+def test_detector_dispatching_to_module_functions_2_types():
+    "Test that correct function gets called when function is of 2 types"
+    assert diff(1, fn_type="foo") == 0
+    assert diff(1, fn_type="bar") == 0
+
+
+def test_detector_dispatching_for_methods_works():
+    "Test that correct instance method gets called when each are of different type"
+    instance = Foo(1)
+    assert instance.add(1, fn_type="foo") == 3
+    assert instance.add(1, fn_type="bar") == "1 2"
+
+def test_detector_dispatching_same_name_method_across_classes():
+    "Test that correct instance method gets called when each are of different type"
+
+    # Create duplicate class with same method as Foo
+    class Foo2():
+        def __init__(self, x):
+            self.x = x
+
+        @detector_dispatcher(types=["foo"])
+        def add(self, data):
+            return data + 20
+
+    instance_1 = Foo(1)
+    instance_2 = Foo2(1)
+
+    assert instance_1.add(1, fn_type="foo") == 3
+    assert instance_2.add(1, fn_type="foo") == 21
+
+### Error Tests #############################################################
+
+def test_decorator_erroring_with_no_type_available_fn():
+    "Test that an error is raised when function to given type is not available"
+    with pytest.raises(ValueError):
+        add(1, fn_type="baz")
+
+
+def test_decorator_error_with_no_fn_type_provided():
+    "Test that an error is raised when no fn_type is provided when calling the function"
+    with pytest.raises(ValueError):
+        add(1)
+
+def test_decorator_erroring_with_duplicate_type_assignment():
+    """Test that an error is raised when same type is assigned to multiple functions
+     of same name in same module
+    """
+    with pytest.raises(ValueError):
+        @detector_dispatcher()
+        def add(data, fn_type="foo"):
+            pass

--- a/vllm_detector_adapter/generative_detectors/granite_guardian.py
+++ b/vllm_detector_adapter/generative_detectors/granite_guardian.py
@@ -156,7 +156,7 @@ class GraniteGuardian(ChatCompletionDetectionBase):
     # Used detector_dispatcher decorator to allow for the same function to be called
     # for different types of detectors with different request types etc.
     @detector_dispatcher(types=[DetectorType.TEXT_CHAT])
-    def preprocess_request( # noqa: F811
+    def preprocess_request(  # noqa: F811
         self, request: ChatDetectionRequest
     ) -> Union[ChatDetectionRequest, ErrorResponse]:
         """Granite guardian chat request preprocess is just detector parameter updates"""

--- a/vllm_detector_adapter/generative_detectors/granite_guardian.py
+++ b/vllm_detector_adapter/generative_detectors/granite_guardian.py
@@ -35,9 +35,6 @@ class GraniteGuardian(ChatCompletionDetectionBase):
     PROMPT_CONTEXT_ANALYSIS_RISKS = ["context_relevance"]
     RESPONSE_CONTEXT_ANALYSIS_RISKS = ["groundedness"]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     ##### Private / Internal functions ###################################################
 
     def __preprocess(
@@ -149,6 +146,11 @@ class GraniteGuardian(ChatCompletionDetectionBase):
 
     @detector_dispatcher(types=[DetectorType.TEXT_CONTENT])
     def preprocess_request(self, *args, **kwargs):
+        # FIXME: This function delcaration is temporary and should be removed once we fix following
+        # issue with decorator:
+        # ISSUE: Because of inheritance, the base class function with same name gets overriden by the function
+        # declared below for preprocessing TEXT_CHAT type detectors. This fails the validation inside
+        # the detector_dispatcher decorator.
         return super().preprocess_request(
             *args, **kwargs, fn_type=DetectorType.TEXT_CONTENT
         )

--- a/vllm_detector_adapter/generative_detectors/granite_guardian.py
+++ b/vllm_detector_adapter/generative_detectors/granite_guardian.py
@@ -146,7 +146,7 @@ class GraniteGuardian(ChatCompletionDetectionBase):
 
     @detector_dispatcher(types=[DetectorType.TEXT_CONTENT])
     def preprocess_request(self, *args, **kwargs):
-        # FIXME: This function delcaration is temporary and should be removed once we fix following
+        # FIXME: This function declaration is temporary and should be removed once we fix following
         # issue with decorator:
         # ISSUE: Because of inheritance, the base class function with same name gets overriden by the function
         # declared below for preprocessing TEXT_CHAT type detectors. This fails the validation inside

--- a/vllm_detector_adapter/generative_detectors/granite_guardian.py
+++ b/vllm_detector_adapter/generative_detectors/granite_guardian.py
@@ -35,6 +35,9 @@ class GraniteGuardian(ChatCompletionDetectionBase):
     PROMPT_CONTEXT_ANALYSIS_RISKS = ["context_relevance"]
     RESPONSE_CONTEXT_ANALYSIS_RISKS = ["groundedness"]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
     ##### Private / Internal functions ###################################################
 
     def __preprocess(
@@ -144,10 +147,16 @@ class GraniteGuardian(ChatCompletionDetectionBase):
 
     ##### General request / response processing functions ##################
 
+    @detector_dispatcher(types=[DetectorType.TEXT_CONTENT])
+    def preprocess_request(self, *args, **kwargs):
+        return super().preprocess_request(
+            *args, **kwargs, fn_type=DetectorType.TEXT_CONTENT
+        )
+
     # Used detector_dispatcher decorator to allow for the same function to be called
     # for different types of detectors with different request types etc.
     @detector_dispatcher(types=[DetectorType.TEXT_CHAT])
-    def preprocess_request(
+    def preprocess_request( # noqa: F811
         self, request: ChatDetectionRequest
     ) -> Union[ChatDetectionRequest, ErrorResponse]:
         """Granite guardian chat request preprocess is just detector parameter updates"""


### PR DESCRIPTION
Closes: #29 

- Add unit tests for detector dispatcher
- Add function declaration for preprocess_request for granite guardian as its not getting pulled from the base class. The issue here is that, because of inheritance, the decorator's validation function doesn't see the base class function with same name but different decorated type. So we basically loose that information in the child class. The fix in this PR is temporary as its not ideal to have multiple declaration everywhere.  So, we'll try to refactor decorator to address this issue. However, since this was breaking functionality, I am pushing this as a critical fix.