### PR TITLE
:sparkles: Add risk bank extraction method

### DIFF
--- a/tests/generative_detectors/test_base.py
+++ b/tests/generative_detectors/test_base.py
@@ -89,6 +89,7 @@ async def _async_serving_detection_completion_init():
         chat_template_content_format="auto",
         request_logger=None,
     )
+    setattr(detection_completion, "RISK_BANK_VAR_NAME", "DUMMY_RISK_BANK")
     return detection_completion
 
 
@@ -196,3 +197,11 @@ def test_content_analysis_success(detection_base, completion_response):
         assert detections[1][0]["score"] == 0.9
         assert detections[1][0]["start"] == 0
         assert detections[1][0]["end"] == len(content_request.contents[1])
+
+
+def test_risk_bank_absense_errors(detection_base):
+    """Test that absesnce of risk bank raises a ValueError"""
+    base_instance = asyncio.run(detection_base)
+    delattr(base_instance, "RISK_BANK_VAR_NAME")
+    with pytest.raises(ValueError) as e:
+        base_instance._get_predifined_risk_bank()

--- a/tests/generative_detectors/test_base.py
+++ b/tests/generative_detectors/test_base.py
@@ -200,8 +200,9 @@ def test_content_analysis_success(detection_base, completion_response):
 
 
 def test_risk_bank_absence_errors(detection_base):
-    """Test that absence of risk bank raises a ValueError"""
+    """Test that absence of risk bank raises a ValueError when trying to get the risk bank objects
+    by calling the _get_predefined_risk_bank method"""
     base_instance = asyncio.run(detection_base)
     delattr(base_instance, "RISK_BANK_VAR_NAME")
     with pytest.raises(ValueError) as e:
-        base_instance._get_predifined_risk_bank()
+        base_instance._get_predefined_risk_bank()

--- a/tests/generative_detectors/test_base.py
+++ b/tests/generative_detectors/test_base.py
@@ -199,8 +199,8 @@ def test_content_analysis_success(detection_base, completion_response):
         assert detections[1][0]["end"] == len(content_request.contents[1])
 
 
-def test_risk_bank_absense_errors(detection_base):
-    """Test that absesnce of risk bank raises a ValueError"""
+def test_risk_bank_absence_errors(detection_base):
+    """Test that absence of risk bank raises a ValueError"""
     base_instance = asyncio.run(detection_base)
     delattr(base_instance, "RISK_BANK_VAR_NAME")
     with pytest.raises(ValueError) as e:

--- a/tests/generative_detectors/test_granite_guardian.py
+++ b/tests/generative_detectors/test_granite_guardian.py
@@ -35,7 +35,7 @@ from vllm_detector_adapter.protocol import (
 from vllm_detector_adapter.utils import DetectorType
 
 MODEL_NAME = "ibm-granite/granite-guardian"  # Example granite-guardian model
-CHAT_TEMPLATE = "Dummy chat template for testing {}"
+CHAT_TEMPLATE = '{%- set risk_bank = ({"social_bias": { "user": "User text 1", "assistant": "Assistant text 1"},"jailbreak": { "user": "User text 2", "assistant": "Assistant text 2"},"profanity": {  "user": "User text 3",  "assistant": "Assistant text 3"}}) %}'
 BASE_MODEL_PATHS = [BaseModelPath(name=MODEL_NAME, model_path=MODEL_NAME)]
 
 CONTENT = "Where do I find geese?"
@@ -589,3 +589,11 @@ def test_chat_detection_errors_on_undefined_jinja_error(granite_guardian_detecti
         assert type(detection_response) == ErrorResponse
         assert detection_response.code == HTTPStatus.BAD_REQUEST.value
         assert "Template error" in detection_response.message
+
+
+def test_risk_bank_extraction(granite_guardian_detection):
+    granite_guardian_detection_instance = asyncio.run(granite_guardian_detection)
+
+    risk_bank_objs = granite_guardian_detection_instance.risk_bank_objs
+    assert len(risk_bank_objs) == 3
+    assert risk_bank_objs[0].key.value == "social_bias"

--- a/tests/generative_detectors/test_llama_guard.py
+++ b/tests/generative_detectors/test_llama_guard.py
@@ -34,7 +34,7 @@ from vllm_detector_adapter.protocol import (
 )
 
 MODEL_NAME = "meta-llama/Llama-Guard-3-8B"  # Example llama guard model
-CHAT_TEMPLATE = "Dummy chat template for testing {}"
+CHAT_TEMPLATE = '{%-  set categories = ({"S1": "Violent Crimes.","S2": "Non-Violent Crimes.","S3": "Sex Crimes.","S4": "Child Exploitation."})\n-%}"'
 BASE_MODEL_PATHS = [BaseModelPath(name=MODEL_NAME, model_path=MODEL_NAME)]
 
 
@@ -336,3 +336,11 @@ def test_generation_analyze(llama_guard_detection, llama_guard_completion_respon
         assert detection_0["detection"] == "safe"
         assert detection_0["detection_type"] == "risk"
         assert pytest.approx(detection_0["score"]) == 0.001346767
+
+
+def test_risk_bank_extraction(llama_guard_detection):
+    llama_guard_detection_instance = asyncio.run(llama_guard_detection)
+
+    risk_bank_objs = llama_guard_detection_instance.risk_bank_objs
+    assert len(risk_bank_objs) == 4
+    assert risk_bank_objs[0].key.value == "S1"

--- a/vllm_detector_adapter/generative_detectors/base.py
+++ b/vllm_detector_adapter/generative_detectors/base.py
@@ -50,7 +50,28 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
 
         self.output_template = self.load_template(output_template)
 
+        self.risk_bank_objs = self._get_predifined_risk_bank()
+
     ##### Template functions ###################################################
+
+    def _get_predifined_risk_bank(self) -> List[jinja2.nodes.Pair]:
+        """Get the list of risks defined in the chat template"""
+
+        if not self.RISK_BANK_VAR_NAME:
+            raise ValueError(
+                f"RISK_BANK_VAR_NAME is not defined for {self.__name__} type of models"
+            )
+
+        ast = self.jinja_env.parse(self.chat_template)
+        risk_bank_objs = []
+
+        for node in ast.find_all(nodes.Assign):
+            if node.target.name == self.RISK_BANK_VAR_NAME:
+                risk_node = node
+                for i in risk_node.node.items:
+                    risk_bank_objs.append(i)
+
+        return risk_bank_objs
 
     def load_template(self, template_path: Optional[Union[Path, str]]) -> str:
         """Function to load template

--- a/vllm_detector_adapter/generative_detectors/base.py
+++ b/vllm_detector_adapter/generative_detectors/base.py
@@ -51,11 +51,11 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
         self.output_template = self.load_template(output_template)
 
         if hasattr(self, "RISK_BANK_VAR_NAME"):
-            self.risk_bank_objs = self._get_predifined_risk_bank()
+            self.risk_bank_objs = self._get_predefined_risk_bank()
 
     ##### Template functions ###################################################
 
-    def _get_predifined_risk_bank(self) -> List[jinja2.nodes.Pair]:
+    def _get_predefined_risk_bank(self) -> List[jinja2.nodes.Pair]:
         """Get the list of risks defined in the chat template"""
 
         if not hasattr(self, "RISK_BANK_VAR_NAME"):

--- a/vllm_detector_adapter/generative_detectors/base.py
+++ b/vllm_detector_adapter/generative_detectors/base.py
@@ -50,22 +50,24 @@ class ChatCompletionDetectionBase(OpenAIServingChat):
 
         self.output_template = self.load_template(output_template)
 
-        self.risk_bank_objs = self._get_predifined_risk_bank()
+        if hasattr(self, "RISK_BANK_VAR_NAME"):
+            self.risk_bank_objs = self._get_predifined_risk_bank()
 
     ##### Template functions ###################################################
 
     def _get_predifined_risk_bank(self) -> List[jinja2.nodes.Pair]:
         """Get the list of risks defined in the chat template"""
 
-        if not self.RISK_BANK_VAR_NAME:
+        if not hasattr(self, "RISK_BANK_VAR_NAME"):
             raise ValueError(
-                f"RISK_BANK_VAR_NAME is not defined for {self.__name__} type of models"
+                f"RISK_BANK_VAR_NAME is not defined for {self.__class__.__name__} type of models"
             )
 
         ast = self.jinja_env.parse(self.chat_template)
         risk_bank_objs = []
 
-        for node in ast.find_all(nodes.Assign):
+        # Note: jinja2.nodes.Assign is type of node
+        for node in ast.find_all(jinja2.nodes.Assign):
             if node.target.name == self.RISK_BANK_VAR_NAME:
                 risk_node = node
                 for i in risk_node.node.items:

--- a/vllm_detector_adapter/generative_detectors/granite_guardian.py
+++ b/vllm_detector_adapter/generative_detectors/granite_guardian.py
@@ -39,6 +39,9 @@ class GraniteGuardian(ChatCompletionDetectionBase):
     # Risks associated with generation analysis
     DEFAULT_GENERATION_DETECTION_RISK = "answer_relevance"
 
+    # Risk Bank name defined in the chat template
+    RISK_BANK_VAR_NAME = "risk_bank"
+
     ##### Private / Internal functions ###################################################
 
     def __preprocess(

--- a/vllm_detector_adapter/generative_detectors/llama_guard.py
+++ b/vllm_detector_adapter/generative_detectors/llama_guard.py
@@ -26,6 +26,9 @@ class LlamaGuard(ChatCompletionDetectionBase):
     SAFE_TOKEN = "safe"
     UNSAFE_TOKEN = "unsafe"
 
+    # Risk Bank name defined in the chat template
+    RISK_BANK_VAR_NAME = "categories"
+
     def __post_process_result(self, response, scores, detection_type):
         """Function to process chat completion results for content type detection.
 


### PR DESCRIPTION
### Changes

- Add a method that will get invoked at load time of the model that will extract the risk_bank for the particular model. The risk bank is essentially a list of risks defined in the model, like `categories` for llama-guard and `risk_bank` for granite guardian. 
- Add risk bank variable name for both granite guardian and llama-stack.
   - In llama-stack, in future, it can be used for explanation type features. Issue: https://github.com/foundation-model-stack/vllm-detector-adapter/issues/25