### PR TITLE
:sparkles: Add env var arg parser

### DIFF
--- a/vllm_detector_adapter/api_server.py
+++ b/vllm_detector_adapter/api_server.py
@@ -34,6 +34,7 @@ from vllm_detector_adapter.protocol import (
     DetectionResponse,
     GenerationDetectionRequest,
 )
+from vllm_detector_adapter.utils import LocalEnvVarArgumentParser
 
 TIMEOUT_KEEP_ALIVE = 5  # seconds
 
@@ -314,8 +315,8 @@ if __name__ == "__main__":
     parser = FlexibleArgumentParser(
         description="vLLM OpenAI-Compatible RESTful API server."
     )
-    parser = make_arg_parser(parser)
-
+    # convert to our custom env var arg parser
+    parser = LocalEnvVarArgumentParser(parser=make_arg_parser(parser))
     # Add chat detection params
     parser = add_chat_detection_params(parser)
 

--- a/vllm_detector_adapter/utils.py
+++ b/vllm_detector_adapter/utils.py
@@ -1,5 +1,11 @@
 # Standard
 from enum import Enum, auto
+import argparse
+import os
+
+# Third Party
+from vllm.engine.arg_utils import StoreBoolean
+from vllm.utils import FlexibleArgumentParser
 
 
 class DetectorType(Enum):
@@ -9,3 +15,82 @@ class DetectorType(Enum):
     TEXT_GENERATION = auto()
     TEXT_CHAT = auto()
     TEXT_CONTEXT_DOC = auto()
+
+
+# LocalEnvVarArgumentParser and dependent functions taken from
+# https://github.com/opendatahub-io/vllm-tgis-adapter/blob/main/src/vllm_tgis_adapter/tgis_utils/args.py
+# vllm by default parses args from CLI, not from env vars, but env var overrides
+# may be useful for users. Here, we adopted the functionality inline
+# to not add the vllm-tgis-adapter dependency by default, and in case the
+# dependency becomes outdated
+
+
+def _to_env_var(arg_name: str) -> str:
+    return arg_name.upper().replace("-", "_")
+
+
+def _bool_from_string(val: str) -> bool:
+    return val.lower().strip() == "true" or val == "1"
+
+
+def _switch_action_default(action: argparse.Action) -> None:
+    """Switch to using env var fallback for all args."""
+    env_val = os.environ.get(_to_env_var(action.dest))
+    if not env_val:
+        return
+
+    val: bool | str
+    # type=bool does not have the expected behavior, eg. bool("false") == True
+    # Also handle special actions for boolean args
+    if action.type is bool or type(action) in [
+        argparse._StoreTrueAction,  # noqa: SLF001
+        argparse._StoreFalseAction,  # noqa: SLF001
+        StoreBoolean,
+    ]:
+        val = _bool_from_string(env_val)
+    else:
+        # for non-string args, the string value of the env var will be parsed
+        # based on the action.type when setting from the default value
+        val = env_val
+
+    if action.nargs in ("+", "*"):
+        action.default = [val]
+    else:
+        action.default = val
+
+
+class LocalEnvVarArgumentParser(FlexibleArgumentParser):
+    """Allows env var fallback for all args."""
+
+    class _EnvVarHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
+        def _get_help_string(self, action: argparse.Action) -> str:
+            help_ = super()._get_help_string(action)
+            assert help_ is not None
+
+            if action.dest != "help":
+                help_ += f" [env: {_to_env_var(action.dest)}]"
+            return help_
+
+    def __init__(
+        self,
+        parser: argparse.ArgumentParser | None = None,
+        *,
+        formatter_class: type[
+            argparse.ArgumentDefaultsHelpFormatter
+        ] = _EnvVarHelpFormatter,
+        **kwargs,  # noqa: ANN003
+    ):
+        parents = []
+        if parser:
+            parents.append(parser)
+            for action in parser._actions:  # noqa: SLF001
+                if isinstance(action, argparse._HelpAction):  # noqa: SLF001
+                    continue
+                _switch_action_default(action)
+        super().__init__(
+            formatter_class=formatter_class, parents=parents, add_help=False, **kwargs
+        )
+
+    def _add_action(self, action: argparse.Action) -> argparse.Action:
+        _switch_action_default(action)
+        return super()._add_action(action)


### PR DESCRIPTION
Before this change an env var like the following would not take effect directly since vLLM generally operates on CLI arguments. 
```
        - name: MAX_NUM_SEQS
          value: "21"
```
For users to override with environment varialbes, the vllm-tgis-adapter added a custom parser [here](https://github.com/opendatahub-io/vllm-tgis-adapter/blob/main/src/vllm_tgis_adapter/__main__.py#L111). The vllm-tgis-adapter is not added by default, but if used via `start_with_tgis_adapter`, env vars will already work.

Example log (i.e. `max_num_seqs=None`)
```
INFO 04-04 17:59:51 api_server.py:118] args: Namespace(host=None, port=3000, uvicorn_log_level='info', allow_credentials=False, allowed_origins=['*'], allowed_methods=['*'], allowed_headers=['*'], api_key=None, lora_modules=None, prompt_adapters=None, chat_template=None, chat_template_content_format='auto', response_role='assistant', ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_cert_reqs=0, root_path=None, middleware=[], return_tokens_as_token_ids=False, disable_frontend_multiprocessing=False, enable_request_id_headers=False, enable_auto_tool_choice=False, enable_reasoning=False, reasoning_parser=None, tool_call_parser=None, tool_parser_plugin='', model='ibm-granite/granite-guardian-3.2-5b', task='auto', tokenizer=None, skip_tokenizer_init=False, revision=None, code_revision=None, tokenizer_revision=None, tokenizer_mode='auto', trust_remote_code=False, allowed_local_media_path=None, download_dir=None, load_format='auto', config_format=<ConfigFormat.AUTO: 'auto'>, dtype='auto', kv_cache_dtype='auto', max_model_len=None, guided_decoding_backend='xgrammar', logits_processor_pattern=None, model_impl='auto', distributed_executor_backend=None, pipeline_parallel_size=1, tensor_parallel_size=1, max_parallel_loading_workers=None, ray_workers_use_nsight=False, block_size=None, enable_prefix_caching=None, disable_sliding_window=False, use_v2_block_manager=True, num_lookahead_slots=0, seed=0, swap_space=4, cpu_offload_gb=0, gpu_memory_utilization=0.9, num_gpu_blocks_override=None, max_num_batched_tokens=None, max_num_partial_prefills=1, max_long_partial_prefills=1, long_prefill_token_threshold=0, max_num_seqs=None, max_logprobs=20, disable_log_stats=False, quantization=None, rope_scaling=None, rope_theta=None, hf_overrides=None, enforce_eager=False, max_seq_len_to_capture=8192, disable_custom_all_reduce=False, tokenizer_pool_size=0, tokenizer_pool_type='ray', tokenizer_pool_extra_config=None, limit_mm_per_prompt=None, mm_processor_kwargs=None, disable_mm_preprocessor_cache=False, enable_lora=False, enable_lora_bias=False, max_loras=1, max_lora_rank=16, lora_extra_vocab_size=256, lora_dtype='auto', long_lora_scaling_factors=None, max_cpu_loras=None, fully_sharded_loras=False, enable_prompt_adapter=False, max_prompt_adapters=1, max_prompt_adapter_token=0, device='auto', num_scheduler_steps=1, multi_step_stream_outputs=True, scheduler_delay_factor=0.0, enable_chunked_prefill=None, speculative_model=None, speculative_model_quantization=None, num_speculative_tokens=None, speculative_disable_mqa_scorer=False, speculative_draft_tensor_parallel_size=None, speculative_max_model_len=None, speculative_disable_by_batch_size=None, ngram_prompt_lookup_max=None, ngram_prompt_lookup_min=None, spec_decoding_acceptance_method='rejection_sampler', typical_acceptance_sampler_posterior_threshold=None, typical_acceptance_sampler_posterior_alpha=None, disable_logprobs_during_spec_decoding=None, model_loader_extra_config=None, ignore_patterns=[], preemption_mode=None, served_model_name=None, qlora_adapter_name_or_path=None, otlp_traces_endpoint=None, collect_detailed_traces=None, disable_async_output_proc=False, scheduling_policy='fcfs', scheduler_cls='vllm.core.scheduler.Scheduler', override_neuron_config=None, override_pooler_config=None, compilation_config=None, kv_transfer_config=None, worker_cls='auto', generation_config=None, override_generation_config=None, enable_sleep_mode=False, calculate_kv_scales=False, additional_config=None, disable_log_requests=False, max_log_len=None, disable_fastapi_docs=False, enable_prompt_tokens_details=False, task_template=None, output_template=None, 
```

After the change, example log (i.e. `max_num_seqs=21`)
```
INFO 04-04 18:16:52 api_server.py:119] args: Namespace(host=None, port=3000, uvicorn_log_level='info', allow_credentials=False, allowed_origins=['*'], allowed_methods=['*'], allowed_headers=['*'], api_key=None, lora_modules=None, prompt_adapters=None, chat_template=None, chat_template_content_format='auto', response_role='assistant', ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_cert_reqs=0, root_path=None, middleware=[], return_tokens_as_token_ids=False, disable_frontend_multiprocessing=False, enable_request_id_headers=False, enable_auto_tool_choice=False, enable_reasoning=False, reasoning_parser=None, tool_call_parser=None, tool_parser_plugin='', model='ibm-granite/granite-guardian-3.2-5b', task='auto', tokenizer=None, skip_tokenizer_init=False, revision=None, code_revision=None, tokenizer_revision=None, tokenizer_mode='auto', trust_remote_code=False, allowed_local_media_path=None, download_dir=None, load_format='auto', config_format=<ConfigFormat.AUTO: 'auto'>, dtype='auto', kv_cache_dtype='auto', max_model_len=None, guided_decoding_backend='xgrammar', logits_processor_pattern=None, model_impl='auto', distributed_executor_backend=None, pipeline_parallel_size=1, tensor_parallel_size=1, max_parallel_loading_workers=None, ray_workers_use_nsight=False, block_size=None, enable_prefix_caching=None, disable_sliding_window=False, use_v2_block_manager=True, num_lookahead_slots=0, seed=0, swap_space=4, cpu_offload_gb=0, gpu_memory_utilization=0.9, num_gpu_blocks_override=None, max_num_batched_tokens=None, max_num_partial_prefills=1, max_long_partial_prefills=1, long_prefill_token_threshold=0, max_num_seqs=21, max_logprobs=20, disable_log_stats=False, quantization=None, rope_scaling=None, rope_theta=None, hf_overrides=None, enforce_eager=False, max_seq_len_to_capture=8192, disable_custom_all_reduce=False, tokenizer_pool_size=0, tokenizer_pool_type='ray', tokenizer_pool_extra_config=None, limit_mm_per_prompt=None, mm_processor_kwargs=None, disable_mm_preprocessor_cache=False, enable_lora=False, enable_lora_bias=False, max_loras=1, max_lora_rank=16, lora_extra_vocab_size=256, lora_dtype='auto', long_lora_scaling_factors=None, max_cpu_loras=None, fully_sharded_loras=False, enable_prompt_adapter=False, max_prompt_adapters=1, max_prompt_adapter_token=0, device='auto', num_scheduler_steps=1, multi_step_stream_outputs=True, scheduler_delay_factor=0.0, enable_chunked_prefill=None, speculative_model=None, speculative_model_quantization=None, num_speculative_tokens=None, speculative_disable_mqa_scorer=False, speculative_draft_tensor_parallel_size=None, speculative_max_model_len=None, speculative_disable_by_batch_size=None, ngram_prompt_lookup_max=None, ngram_prompt_lookup_min=None, spec_decoding_acceptance_method='rejection_sampler', typical_acceptance_sampler_posterior_threshold=None, typical_acceptance_sampler_posterior_alpha=None, disable_logprobs_during_spec_decoding=False, model_loader_extra_config=None, ignore_patterns=[], preemption_mode=None, served_model_name=None, qlora_adapter_name_or_path=None, otlp_traces_endpoint=None, collect_detailed_traces=None, disable_async_output_proc=False, scheduling_policy='fcfs', scheduler_cls='vllm.core.scheduler.Scheduler', override_neuron_config=None, override_pooler_config=None, compilation_config=None, kv_transfer_config=None, worker_cls='auto', generation_config=None, override_generation_config=None, enable_sleep_mode=False, calculate_kv_scales=False, additional_config=None, disable_log_requests=False, max_log_len=100, disable_fastapi_docs=False, enable_prompt_tokens_details=False, task_template=None, output_template=None, model_type=<ModelTypes.GRANITE_GUARDIAN: 'granite_guardian'>)
```