### PR TITLE
:heavy_minus_sign: Move vllm to optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,15 +14,17 @@ classifiers = [
 
 dependencies = [
     "orjson>=3.10.16,<3.11",
-    "vllm @ git+https://github.com/vllm-project/vllm.git@v0.7.3 ; sys_platform == 'darwin'",
-    # NOTE: Currently vllm-tgis-adapter doesn't support vLLM 0.8.2, otherwise, vllm-detector-adapter
-    # does work with higher version of vLLM
-    "vllm>=0.7.3,<0.7.4 ; sys_platform != 'darwin'",
 ]
 
 [project.optional-dependencies]
 vllm-tgis-adapter = [
     "vllm-tgis-adapter>=0.6.3,<0.6.4"
+]
+vllm = [
+    "vllm @ git+https://github.com/vllm-project/vllm.git@v0.7.3 ; sys_platform == 'darwin'",
+    # NOTE: Currently vllm-tgis-adapter doesn't support vLLM 0.8.2, otherwise, vllm-detector-adapter
+    # does work with higher version of vLLM
+    "vllm>=0.7.3,<0.7.4 ; sys_platform != 'darwin'",
 ]
 
 ## Dev Extra Sets ##

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ description = run tests with pytest with coverage
 extras =
     all
     dev-test
+    vllm
 passenv =
     LOG_LEVEL
     LOG_FILTERS
@@ -15,7 +16,7 @@ passenv =
 setenv =
     DFTYPE = pandas_all
 
-commands = pytest --cov=vllm_detector_adapter --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests} -W error::UserWarning 
+commands = pytest --cov=vllm_detector_adapter --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests} -W error::UserWarning
 ; -W ignore::DeprecationWarning
 
 ; Unclear: We probably want to test wheel packaging


### PR DESCRIPTION
### Changes

Currently if there is a mismatch between vLLM in base image and defined in our `pyproject.toml`, then version mentioned in `pyproject.toml` can get installed in the docker container. This somewhat defeats the purpose of the slim installation mechanism we have.

This PR moves vllm to optional dependency and particularly installs it for testing. 