### PR TITLE
Reverse role ordering of context analysis for granite guardian

### DIFF
--- a/tests/generative_detectors/test_granite_guardian.py
+++ b/tests/generative_detectors/test_granite_guardian.py
@@ -485,10 +485,10 @@ def test_request_to_chat_completion_request_prompt_analysis(granite_guardian_det
     )
     assert type(chat_request) == ChatCompletionRequest
     assert len(chat_request.messages) == 2
-    assert chat_request.messages[0]["role"] == "user"
-    assert chat_request.messages[0]["content"] == CONTENT
-    assert chat_request.messages[1]["role"] == "context"
-    assert chat_request.messages[1]["content"] == "extra! " + CONTEXT_DOC
+    assert chat_request.messages[0]["role"] == "context"
+    assert chat_request.messages[0]["content"] == "extra! " + CONTEXT_DOC
+    assert chat_request.messages[1]["role"] == "user"
+    assert chat_request.messages[1]["content"] == CONTENT
     assert chat_request.model == MODEL_NAME
     # detector_paramas
     assert chat_request.n == 2

--- a/vllm_detector_adapter/generative_detectors/granite_guardian.py
+++ b/vllm_detector_adapter/generative_detectors/granite_guardian.py
@@ -282,8 +282,8 @@ class GraniteGuardian(ChatCompletionDetectionBase):
         elif risk_name in self.PROMPT_CONTEXT_ANALYSIS_RISKS:
             # Prompt analysis
             messages = [
-                {"role": "user", "content": content},
                 {"role": "context", "content": context_text},
+                {"role": "user", "content": content},
             ]
         else:
             # Return error if risk names are not expected ones


### PR DESCRIPTION
## What does this PR do
There was a bug reported for the context/doc detector endpoint during functional testing for granite guardian version 3.2. The issue was found to be a difference in the chat templates between older versions of granite guardian and version 3.2.

The PR provides a fix for the latest version of granite guardian by reversing the ordering of roles for content analysis to match the chat template for granite guardian version 3.2

## How was this tested
This PR was tested by running a curl command that revealed this error for context analysis request, using a beta image with changes in this branch: 
```
curl -X 'POST' \
  'http://localhost:3000/api/v1/text/context/doc' \
   -H 'accept: application/json' \
   -H 'detector-id: granite-guardian' \
   -H 'Content-Type: application/json' \
   -d '{
    "content": "What is the history of treaty making?",
    "context_type": "docs",
    "context": [
        "One significant part of treaty making is that signing a treaty implies recognition that the other side is a sovereign state and that the agreement being considered is enforceable under international law. Hence, nations can be very careful about terming an agreement to be a treaty. For example, within the United States, agreements between states are compacts and agreements between states and the federal government or between agencies of the government are memoranda of understanding."
    ],
    "detector_params": {"risk_name": "context_relevance"}
  }'
[{"detection":"Yes","detection_type":"risk","score":0.977022647857666,"metadata":{"confidence":"High"}}]
```

Before this fix, the following error message had occurred: 
```
{'object': 'error', 'message': "unknown primary role: context'", 'type': 'BadRequestError', 'param': None, 'code': 400}
```