### PR TITLE
:recycle: Consolidate args

### DIFF
--- a/vllm_detector_adapter/utils.py
+++ b/vllm_detector_adapter/utils.py
@@ -4,8 +4,7 @@ import argparse
 import os
 
 # Third Party
-from vllm.engine.arg_utils import StoreBoolean
-from vllm.utils import FlexibleArgumentParser
+from vllm.utils import FlexibleArgumentParser, StoreBoolean
 
 
 class DetectorType(Enum):


### PR DESCRIPTION
The separate `vllm.engine.arg_utils` will not work with the latest vllm versions, but using `vllm.utils` is also backwards compatible