### PR TITLE
Remove role_override detector_param support for text/content endpoint for llama guard

### DIFF
--- a/vllm_detector_adapter/generative_detectors/llama_guard.py
+++ b/vllm_detector_adapter/generative_detectors/llama_guard.py
@@ -135,9 +135,9 @@ class LlamaGuard(ChatCompletionDetectionBase):
                 # task template to be applied
                 return request
 
-        # Validate whether role_override was passed as a detector_param, which is invalid for llama guard,
-        # because conversation roles are expected to alternate between 'user' and 'assistant' roles. 
-        # Therefore explicitly overriding the conversation roles will result in an error.
+        # Because conversation roles are expected to alternate between 'user' and 'assistant'
+        # validate whether role_override was passed as a detector_param, which is invalid
+        # since explicitly overriding the conversation roles will result in an error.
         if "role_override" in request.detector_params:
             return ErrorResponse(
                 message="role_override is an invalid parameter for llama guard",


### PR DESCRIPTION
## What this PR does
This PR addresses a bug when adding a role_override to the llama guard text/content endpoint, where explicit role ordering is expected to be preserved:
```
curl -X 'POST' \
  'http:localhost:3000/api/v1/text/contents' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
       "contents": [
            "How can I figure out the pin code to a phone?"
        ],
        "detector_params": {"role_override": "assistant", "risk_name": "harm"}
  }'
  {"object":"error","message":"Conversation roles must alternate user/assistant/user/assistant/...","type":"BadRequestError","param":null,"code":400}
```

This PR fixes that by removing role_override support for llama guard, adding an error check if the detector param is present. 

## How this was tested
A test image was deployed to ensure the error message appears when the role_override detector param is present for the text/content endpoint: 
```
curl -X 'POST' \
  'https://llama-vllm-adapter-fmaas-tuning.apps.fmaas-devstage-backend.fmaas.res.ibm.com/api/v1/text/contents' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
       "contents": [
            "How can I figure out the pin code to a phone?"
        ],
        "detector_params": {"role_override": "assistant", "risk_name": "harm"}
  }'
{"object":"error","message":"role_override is invalid detector parameter for llama guard","type":"BadRequestError","param":null,"code":400}
```

This validated that the former behavior is removed. Furthermore, functional tests were run on this images for llama guard. 