### PR TITLE
:white_check_mark: Initial nightly build and test workflow for latest vllm

### DIFF
--- a/.github/workflows/nightly-build-and-test.yml
+++ b/.github/workflows/nightly-build-and-test.yml
@@ -22,17 +22,18 @@ jobs:
           LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
           echo "LATEST_TAG=${LATEST_TAG:1}" >> $GITHUB_OUTPUT
       - name: Update vllm version to latest
+        id: update-vllm-version
         env:
-          VLLM_TAG: ${{ steps.latest-vllm-tag.outputs.LATEST_TAG}}
+          VLLM_TAG: ${{ steps.latest-vllm-tag.outputs.LATEST_TAG }}
         run: |
-          echo $VLLM_TAG
           python -m pip install --upgrade pip
           pip install tomli-w
           python scripts/update_vllm_version.py --vllm_version $VLLM_TAG
       - name: Install dependencies
+        if: steps.update-vllm-version.outputs.SKIP_VERSION != 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r setup_requirements.txt
       - name: Build and test with tox
+        if: steps.update-vllm-version.outputs.SKIP_VERSION != 'true'
         run: tox -e py
-

--- a/.github/workflows/nightly-build-and-test.yml
+++ b/.github/workflows/nightly-build-and-test.yml
@@ -17,14 +17,18 @@ jobs:
           python-version: 3.11
       - name: Get latest vllm tag
         id: latest-vllm-tag
-        run: echo "LATEST_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/vllm-project/vllm.git | tail -n1 | sed 's/.*\///; s/\^{}//' | sed -e 's/^v//')" >> $GITHUB_OUTPUT
+        run: |
+          git fetch https://github.com/vllm-project/vllm.git --tags 
+          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+          echo "LATEST_TAG=${LATEST_TAG:1}" >> $GITHUB_OUTPUT
       - name: Update vllm version to latest
         env:
           VLLM_TAG: ${{ steps.latest-vllm-tag.outputs.LATEST_TAG}}
         run: |
           echo $VLLM_TAG
-          sed -i -r "s/vllm.git@[^\s]+/vllm.git@v$VLLM_TAG ;/g" pyproject.toml
-          sed -i -r "s/vllm>=[^\s]+/vllm>=$VLLM_TAG,<=$VLLM_TAG ; /g" pyproject.toml
+          python -m pip install --upgrade pip
+          pip install tomli-w
+          python scripts/update_vllm_version.py --vllm_version $VLLM_TAG
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/nightly-build-and-test.yml
+++ b/.github/workflows/nightly-build-and-test.yml
@@ -1,0 +1,34 @@
+name: Nightly Build and Test
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Runs at midnight every day
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Get latest vllm tag
+        id: latest-vllm-tag
+        run: echo "LATEST_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/vllm-project/vllm.git | tail -n1 | sed 's/.*\///; s/\^{}//' | sed -e 's/^v//')" >> $GITHUB_OUTPUT
+      - name: Update vllm version to latest
+        env:
+          VLLM_TAG: ${{ steps.latest-vllm-tag.outputs.LATEST_TAG}}
+        run: |
+          echo $VLLM_TAG
+          sed -i -r "s/vllm.git@[^\s]+/vllm.git@v$VLLM_TAG ;/g" pyproject.toml
+          sed -i -r "s/vllm>=[^\s]+/vllm>=$VLLM_TAG,<=$VLLM_TAG ; /g" pyproject.toml
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r setup_requirements.txt
+      - name: Build and test with tox
+        run: tox -e py
+

--- a/scripts/update_vllm_version.py
+++ b/scripts/update_vllm_version.py
@@ -1,6 +1,7 @@
 # Standard
 import argparse
-import json
+import os
+import sys
 import tomllib
 
 # Third Party
@@ -21,6 +22,11 @@ def parse_args():
     return parser.parse_args()
 
 
+def parse_current_version(vllm_string):
+    version = vllm_string.split("vllm.git@v", 1)[1].split(" ;")[0]
+    return version
+
+
 def main():
 
     args = parse_args()
@@ -29,17 +35,28 @@ def main():
 
     with open("pyproject.toml", "rb") as f:
         data = tomllib.load(f)
-        data["project"]["optional-dependencies"]["vllm"][
-            0
-        ] = f"vllm @ git+https://github.com/vllm-project/vllm.git@v{args.vllm_version} ; sys_platform == 'darwin'"
-        data["project"]["optional-dependencies"]["vllm"][
-            1
-        ] = f"vllm=={args.vllm_version} ; sys_platform != 'darwin'"
+        current_version = parse_current_version(
+            vllm_string=data["project"]["optional-dependencies"]["vllm"][0]
+        )
+        if current_version == args.vllm_version:
+            print(
+                f"VLLM already updated to latest version, skipping update and setting 'SKIP_VERSION' output!"
+            )
+            with open(os.getenv("GITHUB_OUTPUT"), "a") as env:
+                print(f"SKIP_VERSION=true", file=env)
+            sys.exit(0)
+        else:
+            data["project"]["optional-dependencies"]["vllm"][
+                0
+            ] = f"vllm @ git+https://github.com/vllm-project/vllm.git@v{args.vllm_version} ; sys_platform == 'darwin'"
+            data["project"]["optional-dependencies"]["vllm"][
+                1
+            ] = f"vllm=={args.vllm_version} ; sys_platform != 'darwin'"
 
-    with open("pyproject.toml", "wb") as f:
-        tomli_w.dump(data, f)
+            with open("pyproject.toml", "wb") as f:
+                tomli_w.dump(data, f)
 
-    print(f"VLLM version updated to {args.vllm_version} successfully!")
+            print(f"VLLM version updated to {args.vllm_version} successfully!")
 
 
 if __name__ == "__main__":

--- a/scripts/update_vllm_version.py
+++ b/scripts/update_vllm_version.py
@@ -1,7 +1,11 @@
+# Standard
 import argparse
 import json
 import tomllib
+
+# Third Party
 import tomli_w
+
 
 def parse_args():
 
@@ -16,27 +20,27 @@ def parse_args():
     )
     return parser.parse_args()
 
+
 def main():
 
     args = parse_args()
 
-    print(
-        f"Trying to update vllm package version to {args.vllm_version}:"
-    )
+    print(f"Trying to update vllm package version to {args.vllm_version}:")
 
     with open("pyproject.toml", "rb") as f:
         data = tomllib.load(f)
-        data["project"]["optional-dependencies"]["vllm"][0] = (
-            f"vllm @ git+https://github.com/vllm-project/vllm.git@v{args.vllm_version} ; sys_platform == 'darwin'"
-        ) 
-        data["project"]["optional-dependencies"]["vllm"][1] = (
-            f"vllm=={args.vllm_version} ; sys_platform != 'darwin'"
-        )
+        data["project"]["optional-dependencies"]["vllm"][
+            0
+        ] = f"vllm @ git+https://github.com/vllm-project/vllm.git@v{args.vllm_version} ; sys_platform == 'darwin'"
+        data["project"]["optional-dependencies"]["vllm"][
+            1
+        ] = f"vllm=={args.vllm_version} ; sys_platform != 'darwin'"
 
     with open("pyproject.toml", "wb") as f:
         tomli_w.dump(data, f)
 
     print(f"VLLM version updated to {args.vllm_version} successfully!")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/update_vllm_version.py
+++ b/scripts/update_vllm_version.py
@@ -1,0 +1,42 @@
+import argparse
+import json
+import tomllib
+import tomli_w
+
+def parse_args():
+
+    help_str = "Updates vllm version on pyproject.toml"
+    parser = argparse.ArgumentParser(description=help_str)
+    parser.add_argument(
+        "--vllm_version",
+        dest="vllm_version",
+        required=True,
+        type=str,
+        help="Version to overwrite pyproject.toml",
+    )
+    return parser.parse_args()
+
+def main():
+
+    args = parse_args()
+
+    print(
+        f"Trying to update vllm package version to {args.vllm_version}:"
+    )
+
+    with open("pyproject.toml", "rb") as f:
+        data = tomllib.load(f)
+        data["project"]["optional-dependencies"]["vllm"][0] = (
+            f"vllm @ git+https://github.com/vllm-project/vllm.git@v{args.vllm_version} ; sys_platform == 'darwin'"
+        ) 
+        data["project"]["optional-dependencies"]["vllm"][1] = (
+            f"vllm=={args.vllm_version} ; sys_platform != 'darwin'"
+        )
+
+    with open("pyproject.toml", "wb") as f:
+        tomli_w.dump(data, f)
+
+    print(f"VLLM version updated to {args.vllm_version} successfully!")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR resolves https://github.com/foundation-model-stack/vllm-detector-adapter/issues/2

Currently fetching for latest tag on remote [vllm](https://github.com/vllm-project/vllm), updating vllm version on `pyproject.toml`, installing dependencies and running build/test with tox, scheduled to run each day at midnight (cron `"0 0 * * *"`).

Tested locally via [act](https://github.com/nektos/act) (except scheduling).