### PR TITLE
Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG BASE_UBI_IMAGE_TAG=9.5
 ARG PYTHON_VERSION=3.12
 
 ### Build layer
-FROM quay.io/vllm/vllm:0.8.5.0_cu128 as build
+FROM quay.io/modh/vllm:rhoai-2.23-cuda as build
 
 ARG PYTHON_VERSION
 ENV PYTHON_VERSION=${PYTHON_VERSION}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,28 +2,22 @@
 name = "vllm-detector-adapter"
 version = "0.7.1"
 authors = [
-  { name="Gaurav Kumbhat", email="kumbhat.gaurav@gmail.com" },
-  { name="Evaline Ju", email="evaline.ju@ibm.com" },
+    { name = "Gaurav Kumbhat", email = "kumbhat.gaurav@gmail.com" },
+    { name = "Evaline Ju", email = "evaline.ju@ibm.com" },
 ]
 description = "A lightweight adapter layer that provides detector APIs on top of vllm"
 readme = "README.md"
 requires-python = ">=3.11"
-classifiers = [
-    "Programming Language :: Python :: 3"
-]
+classifiers = ["Programming Language :: Python :: 3"]
 
-dependencies = [
-    "orjson>=3.10.16,<3.11",
-]
+dependencies = ["orjson>=3.10.16,<3.11"]
 
 [project.optional-dependencies]
-vllm-tgis-adapter = [
-    "vllm-tgis-adapter>=0.7.0,<0.7.2"
-]
+vllm-tgis-adapter = ["vllm-tgis-adapter>=0.7.0,<0.7.2"]
 vllm = [
     # Note: 0.8.4 has a triton bug on Mac
     "vllm @ git+https://github.com/vllm-project/vllm.git@v0.8.5 ; sys_platform == 'darwin'",
-    "vllm>=0.7.2,<0.8.6 ; sys_platform != 'darwin'",
+    "vllm>=0.7.2,<=0.9 ; sys_platform != 'darwin'",
 ]
 
 ## Dev Extra Sets ##
@@ -36,11 +30,7 @@ dev-test = [
     "wheel>=0.38.4",
 ]
 
-dev-fmt = [
-    "ruff==0.4.7",
-    "pre-commit>=3.0.4,<4.0",
-    "pydeps>=1.12.12,<2",
-]
+dev-fmt = ["ruff==0.4.7", "pre-commit>=3.0.4,<4.0", "pydeps>=1.12.12,<2"]
 
 [tool.setuptools.packages.find]
 where = [""]


### PR DESCRIPTION
Closes #77.

Updates base image to `quay.io/modh/vllm:rhoai-2.23-cuda`.