### PR TITLE
fix: upgrade orjson to 3.11.5+ to fix CVE-2025-67221

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 classifiers = ["Programming Language :: Python :: 3"]
 
-dependencies = ["orjson>=3.10.16,<3.11"]
+dependencies = ["orjson>=3.11.5,<3.12"]
 
 [project.optional-dependencies]
 vllm-tgis-adapter = ["vllm-tgis-adapter>=0.8.0,<0.9.0"]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py, lint, fmt
 [testenv]
 description = run tests with pytest with coverage
 extras =
-    all
     dev-test
     vllm
 passenv =


### PR DESCRIPTION
- Upgrades orjson from >=3.10.16,<3.11 to >=3.11.5,<3.12
- Fixes CVE-2025-67221: recursion DoS vulnerability in orjson.dumps()
- Severity: High (CVSS 7.5)